### PR TITLE
[[ docs ]] fixing wrong function name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 ```js
-var { isGathering, isGatheringUpdate, isAttendee } = require('ssb-gathering-schema')
+var { isGathering, isUpdate, isAttendee } = require('ssb-gathering-schema')
 
 isGathering(msg)
 // => true


### PR DESCRIPTION
The README mentioned a function called `isGatheringUpdate`. That function doesn't exist, the real function is called `isUpdate()`.